### PR TITLE
Update `checkGuess` matching logic

### DIFF
--- a/src/game-helpers.js
+++ b/src/game-helpers.js
@@ -1,3 +1,5 @@
+const SOLVED_CHAR = '/';
+
 export function checkGuess(guess, answer) {
   if (!guess) {
     return null;
@@ -6,20 +8,40 @@ export function checkGuess(guess, answer) {
   const guessChars = guess.toUpperCase().split('');
   const answerChars = answer.split('');
 
-  return guessChars.map((guessChar, index) => {
-    const answerChar = answerChars[index];
+  const result = [];
 
-    let status;
-    if (guessChar === answerChar) {
-      status = 'correct';
-    } else if (answerChars.includes(guessChar)) {
-      status = 'misplaced';
-    } else {
-      status = 'incorrect';
+  // Check for correct characters first, and remove matches from the answer
+  for (let i = 0; i < guessChars.length; i++) {
+    if (guessChars[i] === answerChars[i]) {
+      result[i] = {
+        letter: guessChars[i],
+        status: 'correct',
+      };
+      answerChars[i] = SOLVED_CHAR;
+      guessChars[i] = SOLVED_CHAR;
     }
-    return {
-      letter: guessChar,
+  }
+
+  // Check for misplaced letters from the remaining characters
+  for (let i = 0; i < guessChars.length; i++) {
+    if (guessChars[i] === SOLVED_CHAR) {
+      continue;
+    }
+
+    let status = 'incorrect';
+    const misplacedIndex = answerChars.findIndex(
+      (char) => char === guessChars[i]
+    );
+    if (misplacedIndex >= 0) {
+      status = 'misplaced';
+      answerChars[misplacedIndex] = SOLVED_CHAR;
+    }
+
+    result[i] = {
+      letter: guessChars[i],
       status,
     };
-  });
+  }
+
+  return result;
 }


### PR DESCRIPTION
The current implementation of `checkGuess` doesn't quite match Wordle's behavior. The difference is easiest to spot when dealing with repeated letters. 

For an example, the answer word below is `SOUTH`. Word Game shows the following result when guessing `TRUSS`. By Wordle rules, the interpretation of the result here would indicate that there are two letter `S` in the solution, both of which are misplaced.

<img width="400" alt="Screenshot 2023-02-07 at 7 53 38 PM" src="https://user-images.githubusercontent.com/2423092/217429332-6eaaefc2-f2d0-4a02-b905-4cf5c16fc399.png">

~

Instead, the expected result in Wordle would look like the following, which indicates that the `S` and `T` are misplaced, and then the answer has two other letters, neither of which are `R` or `S`.
<img width="300" alt="Screenshot 2023-02-07 at 7 54 06 PM" src="https://user-images.githubusercontent.com/2423092/217429976-d1f5044d-e230-4a8c-8a07-53ce9bac8df9.png">

~

This PR updates the `checkGuess` function to apply the Wordle matching logic to the guesses.
- First find all matching letters and mark those as correct
- Then look for misplaced letters from the remaining candidates and mark those
- The remainder are incorrect